### PR TITLE
Use conda-forge lib3mf

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -62,20 +62,6 @@ rsync -avm --include="*${SHLIB_EXT}" --include="*/" --exclude="*" \
       "${SRC_DIR}/pymeshlab/lib/" "${PREFIX}/lib/"
 
 ###############################################################################
-# 3.5 Copy the vendored lib3mf into the right place for each OS
-###############################################################################
-# Windows dlls belong in $PREFIX/Library/bin; others go to $PREFIX/lib
-if [[ "${target_platform}" == win-* ]]; then
-  dest_dir="${PREFIX}/Library/bin"
-else
-  dest_dir="${PREFIX}/lib"
-fi
-mkdir -p "${dest_dir}"
-echo "Copying vendored lib3mf into ${dest_dir}"
-find build -type f -name "*lib3mf*${SHLIB_EXT}*" \
-     -exec cp -v '{}' "${dest_dir}/" \; || true
-
-###############################################################################
-# 4. Install the Python wheel into the conda environment
+# 3.5 Install the Python wheel into the conda environment
 ###############################################################################
 "${PYTHON}" -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   - url: https://github.com/cnr-isti-vclab/meshlab/archive/dc48b91ae562756a6988048c5d5c7f1d2b687256.tar.gz
     sha256: bac9cc42614ab5318f4c571a6d28eac7c1bfde69b601f9781d3e118d5a054da0
     folder: src/meshlab
+    patches:
+      - patches/0001-use-system-lib3mf.patch
   - url: https://github.com/cnr-isti-vclab/vcglib/archive/c94ef4e12e9ea3ae986d9af91005be8328d13719.tar.gz
     sha256: 346ff5386be9454fc6b70552d6e397c3d82efd3f8097bf06704c7a44ba3296d5
     folder: src/meshlab/src/vcglib
@@ -19,14 +21,12 @@ source:
     folder: src/pymeshlab/pybind11
 
 build:
-  number: 2
+  number: 3
   missing_dso_whitelist:
     - '*/external-glew.dll'    # [win]
     - '*/external-lib3ds.dll'  # [win]
     - '*/IDTF.dll'             # [win]
     - '*/meshlab-common.dll'   # [win]
-    - '$RPATH/lib3mf.so.2'     # [unix]
-    - '*/lib3mf.dll'           # [win]
   skip: true  # [win and py>310]
 
 requirements:

--- a/recipe/patches/0001-use-system-lib3mf.patch
+++ b/recipe/patches/0001-use-system-lib3mf.patch
@@ -1,0 +1,19 @@
+diff --git a/src/external/lib3mf.cmake b/src/external/lib3mf.cmake
+index 4eced1d..c1c2a83 100644
+--- a/src/external/lib3mf.cmake
++++ b/src/external/lib3mf.cmake
+@@ -20,7 +20,13 @@
+ 
+ option(MESHLAB_ALLOW_DOWNLOAD_SOURCE_LIB3MF "Allow download and use of lib3MF source" ON)
+ 
+-if(MESHLAB_ALLOW_DOWNLOAD_SOURCE_LIB3MF)
++find_package(lib3mf CONFIG QUIET)
++if(TARGET lib3mf::lib3mf)
++  message(STATUS "- Lib3MF - Using system Lib3MF")
++  add_library(external-lib3mf INTERFACE)
++  target_link_libraries(external-lib3mf INTERFACE lib3mf::lib3mf)
++
++elseif(MESHLAB_ALLOW_DOWNLOAD_SOURCE_LIB3MF)
+   set(LIB3MF_VERSION "2.4.1")
+ 
+   set(LIB3MF_DIR ${MESHLAB_EXTERNAL_DOWNLOAD_DIR}/lib3mf-${LIB3MF_VERSION})


### PR DESCRIPTION
## Summary
- patch MeshLab's lib3mf external to prefer conda-forge `lib3mf::lib3mf` via `find_package(lib3mf CONFIG QUIET)`
- remove the vendored lib3mf copy step and matching missing-DSO whitelist entries
- bump the build number because the package linkage/payload changes

## Validation
- `patch --dry-run -p1` against MeshLab `dc48b91ae562756a6988048c5d5c7f1d2b687256`
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- `pixi exec -s lib3mf=2.4.1 -s cmake -s ninja -s cxx-compiler ...` minimal CMake consumer using `find_package(lib3mf CONFIG REQUIRED)`, linking `lib3mf::lib3mf`, and calling `Lib3MF::CWrapper::loadLibrary()`